### PR TITLE
Cytolone launcher

### DIFF
--- a/CYTOLONE/app.py
+++ b/CYTOLONE/app.py
@@ -1,7 +1,9 @@
 import os
 import re
+import base64
 import numpy as np
 import gradio as gr
+from io import BytesIO
 from functools import partial
 from PIL import Image
 
@@ -26,12 +28,46 @@ model_cache = {}
 processor_cache = {}
 llm_model_cache = {}
 llm_tokenizer_cache = {}
+TARGET_SIZE = 1024
 
 PAGE_TABS_CSS = """
 #page-tabs > .tab-wrapper > .tab-container[role="tablist"] > button:not([data-tab-id="launcher"]),
 #page-tabs > .tab-wrapper > .tab-container.visually-hidden > button:not(:first-child),
 #page-tabs > .tab-wrapper > .overflow-menu {
     display: none !important;
+}
+"""
+
+CAPTURE_CURRENT_VIEW_JS = """
+(choiceCaption, imageValue, capturePayload) => {
+    const root = document.querySelector("#cytolone-image-input");
+    const video = root?.querySelector("video");
+
+    if (!video || !video.videoWidth || !video.videoHeight) {
+        return [choiceCaption, imageValue, null];
+    }
+
+    const sourceSize = Math.min(video.videoWidth, video.videoHeight);
+    const sourceX = Math.floor((video.videoWidth - sourceSize) / 2);
+    const sourceY = Math.floor((video.videoHeight - sourceSize) / 2);
+    const canvas = document.createElement("canvas");
+    canvas.width = sourceSize;
+    canvas.height = sourceSize;
+    const context = canvas.getContext("2d");
+
+    context.drawImage(
+        video,
+        sourceX,
+        sourceY,
+        sourceSize,
+        sourceSize,
+        0,
+        0,
+        sourceSize,
+        sourceSize
+    );
+
+    return [choiceCaption, imageValue, canvas.toDataURL("image/png")];
 }
 """
 
@@ -77,29 +113,92 @@ def clean_llm_output(text):
 
     return text.strip()
 
-def center_crop(image, size=1024):
-    if isinstance(image["composite"], np.ndarray):
-        image = Image.fromarray(image["composite"])
+def data_url_to_pil_image(data_url):
+    header, encoded = data_url.split(",", 1)
+    if not header.startswith("data:image/"):
+        raise gr.Error("Unsupported captured image format. Please try again.")
 
-    width, height = image["composite"].size
+    return Image.open(BytesIO(base64.b64decode(encoded)))
+
+def as_pil_image(image):
+    if image is None:
+        raise gr.Error("Please select a webcam or upload an image before analyzing.")
+
+    if isinstance(image, dict):
+        background = image.get("background")
+        image = background if background is not None else image.get("composite")
+
+    if isinstance(image, np.ndarray):
+        image = Image.fromarray(image)
+    elif isinstance(image, str):
+        if image.startswith("data:image/"):
+            image = data_url_to_pil_image(image)
+        else:
+            image = Image.open(image)
+
+    if not isinstance(image, Image.Image):
+        raise gr.Error("Unsupported image input. Please capture or upload an image again.")
+
+    return image.convert("RGB")
+
+def center_crop(image, size):
+    image = as_pil_image(image)
+    width, height = image.size
     left = (width - size) // 2
     top = (height - size) // 2
     right = left + size
     bottom = top + size
-    return image["composite"].crop((left, top, right, bottom))
+    return image.crop((left, top, right, bottom))
 
-def classify_labels(choice_caption, image, specimen, classification_label, order, config):
+def prepare_inference_image(image, config):
+    image = as_pil_image(image)
+    input_size = min(image.size)
+    configured_size = int(config["WEBCAM_IMAGE_SIZE"])
+    scale = TARGET_SIZE / configured_size
+    crop_size = int(TARGET_SIZE * scale)
+    crop_size = max(1, min(crop_size, input_size))
+    cropped_image = center_crop(image, crop_size)
+
+    if cropped_image.size != (TARGET_SIZE, TARGET_SIZE):
+        cropped_image = cropped_image.resize((TARGET_SIZE, TARGET_SIZE))
+
+    return cropped_image, {
+        "scale": scale,
+        "crop_size": crop_size,
+        "original_size": image.size,
+        "inference_size": cropped_image.size,
+    }
+
+def save_debug_preprocess_info(source, preprocess_info, config):
+    save_dir = "debug_images"
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+
+    with open(f"{save_dir}/preprocess_info.txt", "w", encoding="utf-8") as file:
+        file.write(f"source = {source}\n")
+        file.write(f"WEBCAM_IMAGE_SIZE = {config['WEBCAM_IMAGE_SIZE']}\n")
+        file.write(f"scale = {preprocess_info['scale']:.6f}\n")
+        file.write(f"crop_size = {preprocess_info['crop_size']}\n")
+        original_size = preprocess_info["original_size"]
+        inference_size = preprocess_info["inference_size"]
+        file.write(f"original_image_size = {original_size[0]}x{original_size[1]}\n")
+        file.write(f"inference_image_size = {inference_size[0]}x{inference_size[1]}\n")
+
+def classify_labels(choice_caption, image, specimen, classification_label, order, config, source="image_input"):
+    image = as_pil_image(image)
+
     if config["DEBUG"]:
         save_dir = "debug_images"
         if not os.path.exists(save_dir):
             os.makedirs(save_dir)
 
-        image["composite"].save(f"{save_dir}/original_image.jpg")
+        image.save(f"{save_dir}/original_image.jpg")
 
-    image = center_crop(image, size=1024)
+    image, preprocess_info = prepare_inference_image(image, config)
 
     if config["DEBUG"]:
         image.save(f"{save_dir}/cropped_image.jpg")
+        save_debug_preprocess_info(source, preprocess_info, config)
 
     model_path = get_model_id(config["MODEL"])
 
@@ -195,18 +294,25 @@ def refresh_main_page(specimen="cervix"):
         gr.update(choices=choices, value=choices[0] if choices else None),
         build_config_df(config),
         gr.update(
-            canvas_size=(image_size, image_size),
             webcam_options=gr.WebcamOptions(
                 constraints={"video": {"width": image_size, "height": image_size}},
                 mirror=False,
             ),
         ),
+        "",
     )
 
-def classify_with_current_config(choice_caption, image, specimen):
+def select_image_for_analysis(image, captured_image, config):
+    if isinstance(captured_image, str) and captured_image.startswith("data:image/"):
+        return captured_image, "webcam_capture"
+    return image, "image_input"
+
+def classify_with_current_config(choice_caption, image, captured_image, specimen):
     config, question, classification_label, order = get_main_context(specimen)
     if choice_caption not in question:
         choice_caption = next(iter(question))
+
+    image, source = select_image_for_analysis(image, captured_image, config)
 
     return classify_labels(
         choice_caption,
@@ -215,6 +321,7 @@ def classify_with_current_config(choice_caption, image, specimen):
         classification_label=classification_label,
         order=order,
         config=config,
+        source=source,
     )
 
 def generate_comments_with_current_config(choice_caption, label_probs, specimen):
@@ -249,16 +356,11 @@ def build_main_page(specimen="cervix"):
             )
 
         with gr.Column():
-            image_input = gr.ImageEditor(
+            image_input = gr.Image(
                 type="pil",
                 image_mode="RGB",
                 height=500,
                 width=500,
-                canvas_size=(
-                    config["WEBCAM_IMAGE_SIZE"],
-                    config["WEBCAM_IMAGE_SIZE"]
-                    ),
-                fixed_canvas=True,
                 webcam_options=gr.WebcamOptions(
                     constraints={"video": {
                         "width": config["WEBCAM_IMAGE_SIZE"],
@@ -266,9 +368,13 @@ def build_main_page(specimen="cervix"):
                         }},
                     mirror=False),
                 sources=["webcam", "upload"],
-                eraser=False,
-                brush=False,
-                layers=False
+                interactive=True,
+                label="Image",
+                elem_id="cytolone-image-input"
+            )
+            capture_payload = gr.Textbox(
+                value="",
+                visible=False,
             )
 
     submit_btn = gr.Button("Analyze", variant="primary")
@@ -288,8 +394,10 @@ def build_main_page(specimen="cervix"):
         inputs=[
             question_selector,
             image_input,
+            capture_payload,
         ],
-        outputs=label_output
+        outputs=label_output,
+        js=CAPTURE_CURRENT_VIEW_JS,
         )
 
     classify_event.success(
@@ -301,7 +409,7 @@ def build_main_page(specimen="cervix"):
         outputs=comment_output
         )
 
-    return question_selector, config_table, image_input
+    return question_selector, config_table, image_input, capture_payload
 
 def build_model_download_page():
     gr.Markdown("# Model Download")

--- a/CYTOLONE/app.py
+++ b/CYTOLONE/app.py
@@ -16,6 +16,9 @@ from CYTOLONE.label_caption import (
     )
 
 from CYTOLONE.model import get_model_id, get_llm_id
+from CYTOLONE.download_models import download_models_with_status
+from CYTOLONE.scale_check.scale_checker import build_scale_checker_page
+from CYTOLONE.settings_page import apply_settings, build_settings_page, get_settings_values
 
 from CYTOLONE.util import load_config, build_config_df
 
@@ -23,6 +26,14 @@ model_cache = {}
 processor_cache = {}
 llm_model_cache = {}
 llm_tokenizer_cache = {}
+
+PAGE_TABS_CSS = """
+#page-tabs > .tab-wrapper > .tab-container[role="tablist"] > button:not([data-tab-id="launcher"]),
+#page-tabs > .tab-wrapper > .tab-container.visually-hidden > button:not(:first-child),
+#page-tabs > .tab-wrapper > .overflow-menu {
+    display: none !important;
+}
+"""
 
 def get_partial_labels(classification_label, order, order_type):
     if order_type == "Full":
@@ -134,8 +145,9 @@ def classify_labels(choice_caption, image, specimen, classification_label, order
 def generate_comments(choice_caption, label_probs, specimen, config):
     order_type = get_order_type(specimen, config["LANGUAGE"], choice_caption)
     top_labels = sorted(label_probs.items(), key=lambda x: x[1], reverse=True)[:2]
+    threshold = config["LLM_GEN_THRESHOLD"]
 
-    if not (top_labels[0][1] < 0.8 and len(top_labels) > 1 and order_type == "Diagnosis"):
+    if not (top_labels[0][1] < threshold and len(top_labels) > 1 and order_type == "Diagnosis"):
         return " "
 
     llm_model_path = get_llm_id(config["LLM_MODEL"])
@@ -156,6 +168,8 @@ def generate_comments(choice_caption, label_probs, specimen, config):
         prompt = tokenizer.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True
         )
+    else:
+        prompt = caption
 
     generated_text = generate(
         model,
@@ -167,97 +181,229 @@ def generate_comments(choice_caption, label_probs, specimen, config):
 
     return clean_llm_output(generated_text)
 
-def run():
-    # ----------------- #
-    specimen = "cervix"
-    # ----------------- #
-
+def get_main_context(specimen):
     config = load_config()
-
     question, classification_label, order = get_label_caption(specimen, config["LANGUAGE"])
+    return config, question, classification_label, order
 
-    classify_fn = partial(
-        classify_labels,
+def refresh_main_page(specimen="cervix"):
+    config, question, _, _ = get_main_context(specimen)
+    choices = list(question.keys())
+    image_size = config["WEBCAM_IMAGE_SIZE"]
+
+    return (
+        gr.update(choices=choices, value=choices[0] if choices else None),
+        build_config_df(config),
+        gr.update(
+            canvas_size=(image_size, image_size),
+            webcam_options=gr.WebcamOptions(
+                constraints={"video": {"width": image_size, "height": image_size}},
+                mirror=False,
+            ),
+        ),
+    )
+
+def classify_with_current_config(choice_caption, image, specimen):
+    config, question, classification_label, order = get_main_context(specimen)
+    if choice_caption not in question:
+        choice_caption = next(iter(question))
+
+    return classify_labels(
+        choice_caption,
+        image,
         specimen=specimen,
         classification_label=classification_label,
         order=order,
-        config=config
+        config=config,
     )
 
-    with gr.Blocks(title="CYTOLONE") as app:
-        gr.Markdown("# CYTOLONE")
+def generate_comments_with_current_config(choice_caption, label_probs, specimen):
+    config, question, _, _ = get_main_context(specimen)
+    if not config["LLM_GEN"]:
+        return ""
+    if choice_caption not in question:
+        choice_caption = next(iter(question))
 
-        # 入力セクション
-        with gr.Row():
-            with gr.Column():
-                question_selector = gr.Dropdown(
-                    question,
-                    label="Question Type",
-                    scale=1
-                    )
+    return generate_comments(choice_caption, label_probs, specimen=specimen, config=config)
 
-                gr.Dataframe(
-                    value = build_config_df(config),
-                    interactive = False,
-                    row_count = (1, "dynamic"),
-                    col_count = (3, "fixed"),
-                    label = "Settings"
+def build_main_page(specimen="cervix"):
+    config, question, _, _ = get_main_context(specimen)
+
+    gr.Markdown("# CYTOLONE")
+
+    with gr.Row():
+        with gr.Column():
+            question_selector = gr.Dropdown(
+                list(question.keys()),
+                label="Question Type",
+                scale=1,
+                allow_custom_value=True,
                 )
 
-            with gr.Column():
-                image_input = gr.ImageEditor(
-                    type="pil",
-                    image_mode="RGB",
-                    height=500,
-                    width=500,
-                    canvas_size=(
-                        config["WEBCAM_IMAGE_SIZE"],
-                        config["WEBCAM_IMAGE_SIZE"]
-                        ),
-                    fixed_canvas=True,
-                    webcam_options=gr.WebcamOptions(
-                        constraints={"video": {
-                            "width": config["WEBCAM_IMAGE_SIZE"],
-                            "height": config["WEBCAM_IMAGE_SIZE"]
-                            }},
-                        mirror=False),
-                    sources=["webcam", "upload"],
-                    eraser=False,
-                    brush=False,
-                    layers=False
-                )
-
-        submit_btn = gr.Button("Analyze", variant="primary")
-
-        with gr.Row(equal_height=True, variant="panel"):
-            with gr.Column(min_width=300):
-                label_output = gr.Label(label="Result", show_label=True)
-
-            if config["LLM_GEN"]:
-                with gr.Column(min_width=400):
-                    comment_output = gr.Markdown(
-                        label="Comments",
-                        elem_classes="comment-box"
-                    )
-
-        classify_event = submit_btn.click(
-            fn=classify_fn,
-            inputs=[
-                question_selector,
-                image_input,
-            ],
-            outputs=label_output
+            config_table = gr.Dataframe(
+                value = build_config_df(config),
+                interactive = False,
+                row_count = (1, "dynamic"),
+                column_count = (3, "fixed"),
+                label = "Settings"
             )
 
-        if config["LLM_GEN"]:
-            classify_event.success(
-                fn=partial(generate_comments, specimen=specimen, config=config),
-                inputs=[
-                    question_selector,
-                    label_output
-                    ],
-                outputs=comment_output
-                )
+        with gr.Column():
+            image_input = gr.ImageEditor(
+                type="pil",
+                image_mode="RGB",
+                height=500,
+                width=500,
+                canvas_size=(
+                    config["WEBCAM_IMAGE_SIZE"],
+                    config["WEBCAM_IMAGE_SIZE"]
+                    ),
+                fixed_canvas=True,
+                webcam_options=gr.WebcamOptions(
+                    constraints={"video": {
+                        "width": config["WEBCAM_IMAGE_SIZE"],
+                        "height": config["WEBCAM_IMAGE_SIZE"]
+                        }},
+                    mirror=False),
+                sources=["webcam", "upload"],
+                eraser=False,
+                brush=False,
+                layers=False
+            )
+
+    submit_btn = gr.Button("Analyze", variant="primary")
+
+    with gr.Row(equal_height=True, variant="panel"):
+        with gr.Column(min_width=300):
+            label_output = gr.Label(label="Result", show_label=True)
+
+        with gr.Column(min_width=400):
+            comment_output = gr.Markdown(
+                label="Comments",
+                elem_classes="comment-box"
+            )
+
+    classify_event = submit_btn.click(
+        fn=partial(classify_with_current_config, specimen=specimen),
+        inputs=[
+            question_selector,
+            image_input,
+        ],
+        outputs=label_output
+        )
+
+    classify_event.success(
+        fn=partial(generate_comments_with_current_config, specimen=specimen),
+        inputs=[
+            question_selector,
+            label_output
+            ],
+        outputs=comment_output
+        )
+
+    return question_selector, config_table, image_input
+
+def build_model_download_page():
+    gr.Markdown("# Model Download")
+    gr.Markdown("Download models using the current CYTOLONE/config.ini settings.")
+    force_download = gr.Checkbox(label="Force re-download", value=False)
+    download_btn = gr.Button("Download Models", variant="primary")
+    status = gr.Textbox(label="Status", lines=10, interactive=False)
+
+    download_btn.click(
+        fn=download_models_with_status,
+        inputs=force_download,
+        outputs=status,
+    )
+
+def apply_settings_and_refresh_main(language, model, llm_model, llm_gen, llm_threshold, webcam_image_size, debug):
+    settings_outputs = apply_settings(
+        language,
+        model,
+        llm_model,
+        llm_gen,
+        llm_threshold,
+        webcam_image_size,
+        debug,
+    )
+    return (*settings_outputs, *refresh_main_page())
+
+def run():
+    with gr.Blocks(title="CYTOLONE") as app:
+        gr.HTML(f"<style>{PAGE_TABS_CSS}</style>", container=False, show_label=False)
+        with gr.Tabs(selected="launcher", elem_id="page-tabs") as pages:
+            with gr.Tab("Launcher", id="launcher"):
+                gr.Markdown("# CYTOLONE Launcher")
+                with gr.Row():
+                    main_btn = gr.Button("CYTOLONE Main", variant="primary")
+                    scale_btn = gr.Button("scale-check")
+                with gr.Row():
+                    settings_btn = gr.Button("Settings")
+                    model_btn = gr.Button("Model Download")
+
+            with gr.Tab("CYTOLONE Main", id="main"):
+                back_from_main = gr.Button("Back to Launcher")
+                main_refresh_targets = build_main_page()
+
+            with gr.Tab("scale-check", id="scale"):
+                back_from_scale = gr.Button("Back to Launcher")
+                build_scale_checker_page()
+
+            with gr.Tab("Settings", id="settings"):
+                back_from_settings = gr.Button("Back to Launcher")
+                settings_components, settings_apply_btn, settings_status = build_settings_page()
+
+            with gr.Tab("Model Download", id="model"):
+                back_from_model = gr.Button("Back to Launcher")
+                build_model_download_page()
+
+        def show_launcher():
+            return gr.update(selected="launcher")
+
+        def show_main():
+            return (gr.update(selected="main"), *refresh_main_page())
+
+        def show_scale():
+            return gr.update(selected="scale")
+
+        def show_settings():
+            return (gr.update(selected="settings"), *get_settings_values())
+
+        def show_model_download():
+            return gr.update(selected="model")
+
+        main_btn.click(
+            fn=show_main,
+            inputs=None,
+            outputs=[pages, *main_refresh_targets],
+        )
+        scale_btn.click(
+            fn=show_scale,
+            inputs=None,
+            outputs=pages,
+        )
+        settings_btn.click(
+            fn=show_settings,
+            inputs=None,
+            outputs=[pages, *settings_components],
+        )
+        settings_apply_btn.click(
+            fn=apply_settings_and_refresh_main,
+            inputs=settings_components,
+            outputs=[*settings_components, settings_status, *main_refresh_targets],
+        )
+        model_btn.click(
+            fn=show_model_download,
+            inputs=None,
+            outputs=pages,
+        )
+
+        for back_btn in [back_from_main, back_from_scale, back_from_settings, back_from_model]:
+            back_btn.click(
+                fn=show_launcher,
+                inputs=None,
+                outputs=pages,
+            )
 
     app.launch()
 

--- a/CYTOLONE/default_config/config_manager.py
+++ b/CYTOLONE/default_config/config_manager.py
@@ -6,13 +6,19 @@ from configparser import ConfigParser
 CONFIG_PATH = "CYTOLONE/config.ini"
 DEFAULT_CONFIG_PATH = "CYTOLONE/default_config/default_config.ini"
 
-def read_config(path=CONFIG_PATH):
+def read_config(path=CONFIG_PATH, fallback_to_default=True):
     config = ConfigParser()
     config.optionxform = str
-    config.read(path)
+    if os.path.exists(path):
+        config.read(path)
+    elif fallback_to_default and os.path.exists(DEFAULT_CONFIG_PATH):
+        config.read(DEFAULT_CONFIG_PATH)
     return config
 
 def write_config(config, path=CONFIG_PATH):
+    config_dir = os.path.dirname(path)
+    if config_dir:
+        os.makedirs(config_dir, exist_ok=True)
     with open(path, 'w') as configfile:
         config.write(configfile)
 

--- a/CYTOLONE/download_models.py
+++ b/CYTOLONE/download_models.py
@@ -23,20 +23,75 @@ def download_and_flatten(model_id: str, base_output_dir: Path):
 
     print(f"Flattened model '{model_id}' to '{dest_dir}'")
 
-def main():
+def model_is_installed(model_id: str, base_output_dir: Path):
+    dest_dir = base_output_dir / model_id
+    return dest_dir.exists() and any(item.is_file() for item in dest_dir.iterdir())
+
+def get_download_targets(config=None):
+    if config is None:
+        config = load_config()
+
+    targets = [get_model_id(config["MODEL"])]
+    if config["LLM_GEN"]:
+        targets.append(get_llm_id(config["LLM_MODEL"]))
+
+    return targets
+
+def download_models(config=None, output_root=Path("mlx_models"), force=False):
+    targets = get_download_targets(config)
+    downloaded = []
+
+    for model_id in targets:
+        if not force and model_is_installed(model_id, output_root):
+            continue
+        download_and_flatten(model_id, output_root)
+        downloaded.append(model_id)
+
+    return downloaded
+
+def download_models_with_status(force=False):
     config = load_config()
-
-    model_version = config["MODEL"]
-    llm_gen = config["LLM_GEN"]
-
+    targets = get_download_targets(config)
     output_root = Path("mlx_models")
 
-    model_id = get_model_id(model_version)
-    download_and_flatten(model_id, output_root)
+    yield (
+        "Checking models...\n"
+        f"Targets:\n" + "\n".join(f"- {target}" for target in targets)
+    )
 
-    if llm_gen:
-        llm_id = get_llm_id(config["LLM_MODEL"])
-        download_and_flatten(llm_id, output_root)
+    downloaded = []
+    skipped = []
+    try:
+        for model_id in targets:
+            if not force and model_is_installed(model_id, output_root):
+                skipped.append(model_id)
+                yield f"Already installed: {model_id}"
+                continue
+
+            yield f"Downloading {model_id}..."
+            download_and_flatten(model_id, output_root)
+            downloaded.append(model_id)
+    except Exception as exc:  # noqa: BLE001
+        yield (
+            "Model download failed.\n"
+            f"Error: {exc}\n\n"
+            "Downloaded before failure:\n"
+            + ("\n".join(f"- {model_id}" for model_id in downloaded) or "- None")
+            + "\n\nSkipped before failure:\n"
+            + ("\n".join(f"- {model_id}" for model_id in skipped) or "- None")
+        )
+        return
+
+    yield (
+        "Model check completed.\n"
+        "Downloaded models:\n"
+        + ("\n".join(f"- {model_id}" for model_id in downloaded) or "- None")
+        + "\n\nAlready installed:\n"
+        + ("\n".join(f"- {model_id}" for model_id in skipped) or "- None")
+    )
+
+def main():
+    download_models()
 
 if __name__ == "__main__":
     main()

--- a/CYTOLONE/model.py
+++ b/CYTOLONE/model.py
@@ -7,6 +7,9 @@ models = {
     "gpt-oss-20b":{"model_id": "mlx-community/gpt-oss-20b-MXFP4-Q8"},
     }
 
+APP_MODEL_CHOICES = ["v1.0", "v1.1"]
+LLM_MODEL_CHOICES = ["deepseek-r1", "gpt-oss-120b", "gpt-oss-20b"]
+
 def get_model_id(version):
     return models[version]["model_id"]
 

--- a/CYTOLONE/scale_check/scale_checker.py
+++ b/CYTOLONE/scale_check/scale_checker.py
@@ -326,244 +326,248 @@ def apply_scale_to_config(scale):
     return message, status
 
 
-def run():
+def build_scale_checker_page():
     config = load_config()
 
+    gr.Markdown("# Image Scale Checker")
+
+    with gr.Tabs(selected="semi_auto"):
+        with gr.Tab("Semi-Auto", id="semi_auto"):
+            semi_reference_state = gr.State(load_image("Image 1"))
+            semi_input_state = gr.State(None)
+            semi_reference_click_state = gr.State(None)
+            semi_input_click_state = gr.State(None)
+            semi_reference_diameter_state = gr.State(None)
+            semi_input_diameter_state = gr.State(None)
+
+            semi_radio = gr.Radio(
+                choices=list(REFERENCE_IMAGE_FILES.keys()),
+                value="Image 1",
+                label="Select Reference Image",
+            )
+
+            with gr.Row():
+                semi_reference_image = gr.Image(
+                    width=360,
+                    height=360,
+                    type="pil",
+                    label="Reference (Click Squamous Nucleus Center)",
+                    value=load_image("Image 1"),
+                    interactive=True,
+                )
+
+                semi_input_image = gr.Image(
+                    width=360,
+                    height=360,
+                    type="pil",
+                    image_mode="RGB",
+                    sources=["webcam", "upload"],
+                    webcam_options=gr.WebcamOptions(
+                        constraints={
+                            "video": {
+                                "width": config["WEBCAM_IMAGE_SIZE"],
+                                "height": config["WEBCAM_IMAGE_SIZE"],
+                            }
+                        },
+                        mirror=False,
+                    ),
+                    label="Input (Capture/Upload then Click Squamous Nucleus Center)",
+                    interactive=True,
+                )
+
+            with gr.Row():
+                semi_reference_nucleus_preview = gr.Image(
+                    width=260,
+                    height=260,
+                    type="pil",
+                    label="Reference Nucleus Preview",
+                )
+                semi_input_nucleus_preview = gr.Image(
+                    width=260,
+                    height=260,
+                    type="pil",
+                    label="Input Nucleus Preview",
+                )
+
+            with gr.Row():
+                semi_reference_diameter_text = gr.Textbox(
+                    label="Reference Nucleus Diameter",
+                    value="",
+                    interactive=False,
+                )
+                semi_input_diameter_text = gr.Textbox(
+                    label="Input Nucleus Diameter",
+                    value="",
+                    interactive=False,
+                )
+
+            with gr.Row():
+                semi_estimate_btn = gr.Button("Estimate")
+                semi_scale_slider = gr.Slider(
+                    MIN_SCALE,
+                    MAX_SCALE,
+                    step=0.01,
+                    value=1.0,
+                    label="Scale Factor (Auto + Fine Tuning)",
+                )
+                semi_apply_btn = gr.Button("Apply", variant="primary")
+
+            semi_result_slider = gr.ImageSlider(label="Compare Reference vs Adjusted")
+            semi_result_text = gr.Textbox(label="Scale Info", lines=4)
+            semi_status_text = gr.Textbox(label="Status", lines=2, interactive=False)
+            semi_apply_text = gr.Textbox(label="Apply Result", lines=5, interactive=False)
+
+            semi_radio.change(
+                fn=update_reference_for_semi_auto,
+                inputs=semi_radio,
+                outputs=[
+                    semi_reference_state,
+                    semi_reference_image,
+                    semi_reference_click_state,
+                    semi_reference_nucleus_preview,
+                    semi_reference_diameter_state,
+                    semi_reference_diameter_text,
+                    semi_status_text,
+                ],
+            )
+
+            semi_input_image.input(
+                fn=update_input_for_semi_auto,
+                inputs=semi_input_image,
+                outputs=[
+                    semi_input_state,
+                    semi_input_click_state,
+                    semi_input_nucleus_preview,
+                    semi_input_diameter_state,
+                    semi_input_diameter_text,
+                    semi_status_text,
+                ],
+            )
+
+            semi_reference_image.select(
+                fn=on_reference_select,
+                inputs=[semi_reference_state],
+                outputs=[
+                    semi_reference_image,
+                    semi_reference_click_state,
+                    semi_reference_nucleus_preview,
+                    semi_reference_diameter_state,
+                    semi_reference_diameter_text,
+                    semi_status_text,
+                ],
+            )
+
+            semi_input_image.select(
+                fn=on_input_select,
+                inputs=[semi_input_state],
+                outputs=[
+                    semi_input_image,
+                    semi_input_click_state,
+                    semi_input_nucleus_preview,
+                    semi_input_diameter_state,
+                    semi_input_diameter_text,
+                    semi_status_text,
+                ],
+            )
+
+            semi_estimate_btn.click(
+                fn=estimate_scale_from_nuclei,
+                inputs=[
+                    semi_reference_diameter_state,
+                    semi_input_diameter_state,
+                    semi_reference_state,
+                    semi_input_state,
+                ],
+                outputs=[
+                    semi_scale_slider,
+                    semi_result_slider,
+                    semi_result_text,
+                    semi_status_text,
+                ],
+            )
+
+            semi_scale_slider.change(
+                fn=overlay_and_calculate,
+                inputs=[semi_reference_state, semi_input_state, semi_scale_slider],
+                outputs=[semi_result_slider, semi_result_text],
+            )
+
+            semi_apply_btn.click(
+                fn=apply_scale_to_config,
+                inputs=[semi_scale_slider],
+                outputs=[semi_apply_text, semi_status_text],
+            )
+
+        with gr.Tab("Manual", id="manual"):
+            manual_radio = gr.Radio(
+                choices=list(REFERENCE_IMAGE_FILES.keys()),
+                value="Image 1",
+                label="Select Reference Image",
+            )
+
+            with gr.Row():
+                manual_reference_image = gr.Image(
+                    width=300,
+                    height=300,
+                    type="pil",
+                    label="Reference Image Preview",
+                    value=load_image("Image 1"),
+                )
+
+                manual_adjust_input = gr.ImageEditor(
+                    width=300,
+                    height=300,
+                    type="pil",
+                    canvas_size=(
+                        config["WEBCAM_IMAGE_SIZE"],
+                        config["WEBCAM_IMAGE_SIZE"],
+                    ),
+                    fixed_canvas=True,
+                    webcam_options=gr.WebcamOptions(
+                        constraints={
+                            "video": {
+                                "width": config["WEBCAM_IMAGE_SIZE"],
+                                "height": config["WEBCAM_IMAGE_SIZE"],
+                            }
+                        },
+                        mirror=False,
+                    ),
+                    sources=["webcam", "upload"],
+                    eraser=False,
+                    brush=False,
+                    layers=False,
+                    label="Adjust Image Preview",
+                )
+
+            with gr.Row():
+                manual_scale_slider = gr.Slider(
+                    MIN_SCALE,
+                    MAX_SCALE,
+                    step=0.01,
+                    value=1.0,
+                    label="Scale Factor",
+                )
+                manual_compare_btn = gr.Button("Compare")
+
+            manual_result_slider = gr.ImageSlider(label="Compare Reference vs Adjusted")
+            manual_result_text = gr.Textbox(label="Scale Info", lines=4)
+
+            manual_radio.change(
+                fn=load_image,
+                inputs=manual_radio,
+                outputs=manual_reference_image,
+            )
+
+            manual_compare_btn.click(
+                fn=overlay_and_calculate,
+                inputs=[manual_reference_image, manual_adjust_input, manual_scale_slider],
+                outputs=[manual_result_slider, manual_result_text],
+            )
+
+
+def run():
     with gr.Blocks() as app:
-        gr.Markdown("# Image Scale Checker")
-
-        with gr.Tabs(selected="semi_auto"):
-            with gr.Tab("Semi-Auto", id="semi_auto"):
-                semi_reference_state = gr.State(load_image("Image 1"))
-                semi_input_state = gr.State(None)
-                semi_reference_click_state = gr.State(None)
-                semi_input_click_state = gr.State(None)
-                semi_reference_diameter_state = gr.State(None)
-                semi_input_diameter_state = gr.State(None)
-
-                semi_radio = gr.Radio(
-                    choices=list(REFERENCE_IMAGE_FILES.keys()),
-                    value="Image 1",
-                    label="Select Reference Image",
-                )
-
-                with gr.Row():
-                    semi_reference_image = gr.Image(
-                        width=360,
-                        height=360,
-                        type="pil",
-                        label="Reference (Click Squamous Nucleus Center)",
-                        value=load_image("Image 1"),
-                        interactive=True,
-                    )
-
-                    semi_input_image = gr.Image(
-                        width=360,
-                        height=360,
-                        type="pil",
-                        image_mode="RGB",
-                        sources=["webcam", "upload"],
-                        webcam_options=gr.WebcamOptions(
-                            constraints={
-                                "video": {
-                                    "width": config["WEBCAM_IMAGE_SIZE"],
-                                    "height": config["WEBCAM_IMAGE_SIZE"],
-                                }
-                            },
-                            mirror=False,
-                        ),
-                        label="Input (Capture/Upload then Click Squamous Nucleus Center)",
-                        interactive=True,
-                    )
-
-                with gr.Row():
-                    semi_reference_nucleus_preview = gr.Image(
-                        width=260,
-                        height=260,
-                        type="pil",
-                        label="Reference Nucleus Preview",
-                    )
-                    semi_input_nucleus_preview = gr.Image(
-                        width=260,
-                        height=260,
-                        type="pil",
-                        label="Input Nucleus Preview",
-                    )
-
-                with gr.Row():
-                    semi_reference_diameter_text = gr.Textbox(
-                        label="Reference Nucleus Diameter",
-                        value="",
-                        interactive=False,
-                    )
-                    semi_input_diameter_text = gr.Textbox(
-                        label="Input Nucleus Diameter",
-                        value="",
-                        interactive=False,
-                    )
-
-                with gr.Row():
-                    semi_estimate_btn = gr.Button("Estimate")
-                    semi_scale_slider = gr.Slider(
-                        MIN_SCALE,
-                        MAX_SCALE,
-                        step=0.01,
-                        value=1.0,
-                        label="Scale Factor (Auto + Fine Tuning)",
-                    )
-                    semi_apply_btn = gr.Button("Apply", variant="primary")
-
-                semi_result_slider = gr.ImageSlider(label="Compare Reference vs Adjusted")
-                semi_result_text = gr.Textbox(label="Scale Info", lines=4)
-                semi_status_text = gr.Textbox(label="Status", lines=2, interactive=False)
-                semi_apply_text = gr.Textbox(label="Apply Result", lines=5, interactive=False)
-
-                semi_radio.change(
-                    fn=update_reference_for_semi_auto,
-                    inputs=semi_radio,
-                    outputs=[
-                        semi_reference_state,
-                        semi_reference_image,
-                        semi_reference_click_state,
-                        semi_reference_nucleus_preview,
-                        semi_reference_diameter_state,
-                        semi_reference_diameter_text,
-                        semi_status_text,
-                    ],
-                )
-
-                semi_input_image.input(
-                    fn=update_input_for_semi_auto,
-                    inputs=semi_input_image,
-                    outputs=[
-                        semi_input_state,
-                        semi_input_click_state,
-                        semi_input_nucleus_preview,
-                        semi_input_diameter_state,
-                        semi_input_diameter_text,
-                        semi_status_text,
-                    ],
-                )
-
-                semi_reference_image.select(
-                    fn=on_reference_select,
-                    inputs=[semi_reference_state],
-                    outputs=[
-                        semi_reference_image,
-                        semi_reference_click_state,
-                        semi_reference_nucleus_preview,
-                        semi_reference_diameter_state,
-                        semi_reference_diameter_text,
-                        semi_status_text,
-                    ],
-                )
-
-                semi_input_image.select(
-                    fn=on_input_select,
-                    inputs=[semi_input_state],
-                    outputs=[
-                        semi_input_image,
-                        semi_input_click_state,
-                        semi_input_nucleus_preview,
-                        semi_input_diameter_state,
-                        semi_input_diameter_text,
-                        semi_status_text,
-                    ],
-                )
-
-                semi_estimate_btn.click(
-                    fn=estimate_scale_from_nuclei,
-                    inputs=[
-                        semi_reference_diameter_state,
-                        semi_input_diameter_state,
-                        semi_reference_state,
-                        semi_input_state,
-                    ],
-                    outputs=[
-                        semi_scale_slider,
-                        semi_result_slider,
-                        semi_result_text,
-                        semi_status_text,
-                    ],
-                )
-
-                semi_scale_slider.change(
-                    fn=overlay_and_calculate,
-                    inputs=[semi_reference_state, semi_input_state, semi_scale_slider],
-                    outputs=[semi_result_slider, semi_result_text],
-                )
-
-                semi_apply_btn.click(
-                    fn=apply_scale_to_config,
-                    inputs=[semi_scale_slider],
-                    outputs=[semi_apply_text, semi_status_text],
-                )
-
-            with gr.Tab("Manual", id="manual"):
-                manual_radio = gr.Radio(
-                    choices=list(REFERENCE_IMAGE_FILES.keys()),
-                    value="Image 1",
-                    label="Select Reference Image",
-                )
-
-                with gr.Row():
-                    manual_reference_image = gr.Image(
-                        width=300,
-                        height=300,
-                        type="pil",
-                        label="Reference Image Preview",
-                        value=load_image("Image 1"),
-                    )
-
-                    manual_adjust_input = gr.ImageEditor(
-                        width=300,
-                        height=300,
-                        type="pil",
-                        canvas_size=(
-                            config["WEBCAM_IMAGE_SIZE"],
-                            config["WEBCAM_IMAGE_SIZE"],
-                        ),
-                        fixed_canvas=True,
-                        webcam_options=gr.WebcamOptions(
-                            constraints={
-                                "video": {
-                                    "width": config["WEBCAM_IMAGE_SIZE"],
-                                    "height": config["WEBCAM_IMAGE_SIZE"],
-                                }
-                            },
-                            mirror=False,
-                        ),
-                        sources=["webcam", "upload"],
-                        eraser=False,
-                        brush=False,
-                        layers=False,
-                        label="Adjust Image Preview",
-                    )
-
-                with gr.Row():
-                    manual_scale_slider = gr.Slider(
-                        MIN_SCALE,
-                        MAX_SCALE,
-                        step=0.01,
-                        value=1.0,
-                        label="Scale Factor",
-                    )
-                    manual_compare_btn = gr.Button("Compare")
-
-                manual_result_slider = gr.ImageSlider(label="Compare Reference vs Adjusted")
-                manual_result_text = gr.Textbox(label="Scale Info", lines=4)
-
-                manual_radio.change(
-                    fn=load_image,
-                    inputs=manual_radio,
-                    outputs=manual_reference_image,
-                )
-
-                manual_compare_btn.click(
-                    fn=overlay_and_calculate,
-                    inputs=[manual_reference_image, manual_adjust_input, manual_scale_slider],
-                    outputs=[manual_result_slider, manual_result_text],
-                )
+        build_scale_checker_page()
 
     app.launch()
 

--- a/CYTOLONE/settings_page.py
+++ b/CYTOLONE/settings_page.py
@@ -1,0 +1,113 @@
+import gradio as gr
+from configparser import ConfigParser
+
+from CYTOLONE.default_config.config_manager import read_config, write_config
+from CYTOLONE.model import APP_MODEL_CHOICES, LLM_MODEL_CHOICES
+
+
+CONFIG_KEYS = [
+    "LANGUAGE",
+    "MODEL",
+    "LLM_MODEL",
+    "LLM_GEN",
+    "LLM_GEN_THRESHOLD",
+    "WEBCAM_IMAGE_SIZE",
+    "DEBUG",
+]
+
+
+def _settings_section():
+    config = read_config()
+    if "SETTINGS" not in config:
+        config = read_config(path="CYTOLONE/default_config/default_config.ini", fallback_to_default=False)
+    return config["SETTINGS"]
+
+
+def get_settings_values():
+    settings = _settings_section()
+    return (
+        settings["LANGUAGE"],
+        settings["MODEL"],
+        settings["LLM_MODEL"],
+        settings["LLM_GEN"],
+        float(settings["LLM_GEN_THRESHOLD"]),
+        int(settings["WEBCAM_IMAGE_SIZE"]),
+        settings["DEBUG"],
+    )
+
+
+def apply_settings(language, model, llm_model, llm_gen, llm_threshold, webcam_image_size, debug):
+    config = ConfigParser()
+    config.optionxform = str
+    config["SETTINGS"] = {
+        "LANGUAGE": language,
+        "MODEL": model,
+        "LLM_MODEL": llm_model,
+        "LLM_GEN": llm_gen,
+        "LLM_GEN_THRESHOLD": str(llm_threshold),
+        "WEBCAM_IMAGE_SIZE": str(int(webcam_image_size)),
+        "DEBUG": debug,
+    }
+    write_config(config)
+
+    return (*get_settings_values(), (
+        "Settings saved to CYTOLONE/config.ini.\n"
+        "CYTOLONE Main and Model Download will use the updated settings immediately.\n"
+        "If scale-check camera sizing looks stale, reload the app before using scale-check."
+    ))
+
+
+def build_settings_page():
+    values = get_settings_values()
+
+    gr.Markdown("# Settings")
+
+    language = gr.Dropdown(
+        choices=["en", "ja"],
+        value=values[0],
+        label="LANGUAGE",
+    )
+    model = gr.Dropdown(
+        choices=APP_MODEL_CHOICES,
+        value=values[1],
+        label="MODEL",
+    )
+    llm_model = gr.Dropdown(
+        choices=LLM_MODEL_CHOICES,
+        value=values[2],
+        label="LLM_MODEL",
+    )
+    llm_gen = gr.Dropdown(
+        choices=["True", "False"],
+        value=values[3],
+        label="LLM_GEN",
+    )
+    llm_threshold = gr.Number(
+        value=values[4],
+        label="LLM_GEN_THRESHOLD",
+        precision=2,
+    )
+    webcam_image_size = gr.Number(
+        value=values[5],
+        label="WEBCAM_IMAGE_SIZE",
+        precision=0,
+    )
+    debug = gr.Dropdown(
+        choices=["True", "False"],
+        value=values[6],
+        label="DEBUG",
+    )
+
+    apply_btn = gr.Button("Apply", variant="primary")
+    status = gr.Textbox(label="Status", lines=3, interactive=False)
+
+    inputs = [
+        language,
+        model,
+        llm_model,
+        llm_gen,
+        llm_threshold,
+        webcam_image_size,
+        debug,
+    ]
+    return inputs, apply_btn, status

--- a/CYTOLONE/util.py
+++ b/CYTOLONE/util.py
@@ -1,9 +1,9 @@
 import pandas as pd
-from configparser import ConfigParser
+
+from CYTOLONE.default_config.config_manager import read_config
 
 def load_config(config_file_path="./CYTOLONE/config.ini"):
-    parser = ConfigParser()
-    parser.read(config_file_path)
+    parser = read_config(config_file_path)
 
     return {
         "LANGUAGE": parser["SETTINGS"]["LANGUAGE"],

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Below is an example image used in the study:
 </div>
 
 ## 🤩 Update History
-- **xxxx**
-  - Released CYTOLONE v1.1.4!
+- **2026/05/05**
   - Added the CYTOLONE launcher.
   - You can now open CYTOLONE Main, scale-check, Settings, and Model Download from `cytolone`.
+  - Added continuous camera input for smoother microscope workflows.
+  - You no longer need to press the default camera capture button each time. Keep the camera connected and press the **Analyze** button to evaluate the current view.
 
 - **2026/02/16**
   - Released CYTOLONE v1.1.3!

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Below is an example image used in the study:
 </div>
 
 ## 🤩 Update History
+- **xxxx**
+  - Released CYTOLONE v1.1.4!
+  - Added the CYTOLONE launcher.
+  - You can now open CYTOLONE Main, scale-check, Settings, and Model Download from `cytolone`.
+
 - **2026/02/16**
   - Released CYTOLONE v1.1.3!
   - Made `scale-check` semi-automated!
@@ -137,6 +142,8 @@ Below is an example image used in the study:
       ```
 
     - How to change settings
+      - You can edit settings from the launcher: run `cytolone` or `uv run cytolone`, then open **Settings**.
+      - The CLI commands remain available.
       - Display all settings: 
         ```bash
         cytolone-config --list
@@ -164,6 +171,9 @@ Below is an example image used in the study:
     <br>
 
     - Download the models
+      - You can download models from the launcher: run `cytolone` or `uv run cytolone`, then open **Model Download**.
+      - Already installed models are skipped automatically. Use **Force re-download** only when you want to download again.
+      - The CLI command remains available.
       ```bash
       download-model
       ```
@@ -193,7 +203,15 @@ Below is an example image used in the study:
     ```bash
     cytolone
     ```
+    or:
+    ```bash
+    uv run cytolone
+    ```
+    - The CYTOLONE launcher opens first.
+    - From the launcher, you can open CYTOLONE Main, scale-check, Settings, and Model Download.
+    - Only the Launcher tab is shown in the navigation bar; use the launcher buttons to open each page.
     - Open the URL displayed in the terminal in your web browser.
+    - Click **CYTOLONE Main** to open the existing analysis screen.
     - Simply select your camera, capture an image, and click the Analyze button to view the results.
 
     <br>

--- a/README_JA.md
+++ b/README_JA.md
@@ -34,6 +34,11 @@ _**"Always by you side."**_
 </div>
 
 ## 🤩 アップデート履歴
+- **xxxx**
+  - CYTOLONE-v1.1.4 をリリース！
+  - CYTOLONE ランチャーを追加しました！
+  - `cytolone` から CYTOLONE メイン、scale-check、設定変更、モデルDL を開けるようになりました。
+
 - **2026年2月16日**
   - CYTOLONE-v1.1.3 をリリース！
   - scale-checkを半自動化しました！
@@ -135,6 +140,8 @@ _**"Always by you side."**_
         ```
 
     - 設定変更方法
+        - ランチャーから設定を変更できます。`cytolone` または `uv run cytolone` を実行し、**Settings** を開いてください。
+        - CLI コマンドも引き続き利用できます。
         - 設定一覧を表示: 
           ```bash
           cytolone-config --list
@@ -161,6 +168,9 @@ _**"Always by you side."**_
     <br>
 
     - モデルのダウンロード
+      - ランチャーからモデルをダウンロードできます。`cytolone` または `uv run cytolone` を実行し、**Model Download** を開いてください。
+      - すでにインストール済みのモデルは自動的にスキップされます。再ダウンロードしたい場合のみ **Force re-download** を使用してください。
+      - CLI コマンドも引き続き利用できます。
       ```bash
       download-model
       ```
@@ -189,7 +199,15 @@ _**"Always by you side."**_
     ```bash
     cytolone
     ```
+    または:
+    ```bash
+    uv run cytolone
+    ```
+    - 最初に CYTOLONE ランチャー画面が開きます。
+    - ランチャーから CYTOLONE メイン、scale-check、設定変更、モデルDL を開けます。
+    - ナビゲーションバーには Launcher タブだけが表示されます。各ページへはランチャー内のボタンから移動してください。
     - ターミナルに表示されたアドレスにWebブラウザでアクセスする。  
+    - **CYTOLONE Main** を押すと、従来の解析画面が開きます。
     - カメラ選択 → 写真撮影 → **Analyze ボタンをクリック** するだけで判定結果が表示されます。
 
     <br>

--- a/README_JA.md
+++ b/README_JA.md
@@ -34,10 +34,11 @@ _**"Always by you side."**_
 </div>
 
 ## 🤩 アップデート履歴
-- **xxxx**
-  - CYTOLONE-v1.1.4 をリリース！
-  - CYTOLONE ランチャーを追加しました！
-  - `cytolone` から CYTOLONE メイン、scale-check、設定変更、モデルDL を開けるようになりました。
+- **2026年5月5日**
+  - CYTOLONE ランチャーを実装しました。
+  - `cytolone` から CYTOLONE Main、scale-check、Settings、Model Download を開けるようになりました。
+  - 顕微鏡ワークフロー向けに、継続したカメラ入力に対応しました。
+  - これまでのように毎回カメラの撮影ボタンを押す必要はありません。カメラ接続を維持したまま、**Analyze** ボタンで現在の視野を判定できます。
 
 - **2026年2月16日**
   - CYTOLONE-v1.1.3 をリリース！

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "CYTOLONE"
-version = "1.1.3"
+version = "1.1.4"
 requires-python = "==3.12.*"
 dependencies = [
     "accelerate>=1.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "cytolone"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary

This PR adds a CYTOLONE launcher to the existing `cytolone` entry point.

`uv run cytolone` / `cytolone` now opens a launcher first, instead of going directly to the main CYTOLONE screen. From the launcher, users can open:

- CYTOLONE Main
- scale-check
- Settings
- Model Download

No new entry point is added.

## Changes

- Added launcher-based navigation to `CYTOLONE.app:run`
- Kept the existing CYTOLONE Main screen and embedded it as a launcher page
- Reused the existing scale-check UI inside the launcher while keeping `scale-check` CLI compatibility
- Added a new Settings page for editing `CYTOLONE/config.ini`
- Added default-config fallback behavior when `config.ini` is missing
- Added Model Download page
  - Uses the current `config.ini`
  - Skips already installed models
  - Supports `Force re-download`
- Updated model download helper functions for launcher use
- Updated README / README_JA for launcher workflow
- Bumped version from `1.1.3` to `1.1.4`
- Improved iPhone webcam handling on the CYTOLONE Main screen
  - Keeps `sources=["webcam", "upload"]` support
  - Allows users to analyze the currently displayed webcam view from the `Analyze` button without relying on Gradio's built-in webcam capture button
  - Prevents the webcam preview from being replaced by a captured still image after analysis
  - Preserves still-image upload analysis
- Replaced the main screen input from `ImageEditor` to `Image` to avoid upload images being resized to the webcam canvas size
- Aligned main inference preprocessing with the scale-check workflow
  - Computes crop size from `WEBCAM_IMAGE_SIZE`
  - Center-crops the input view accordingly
  - Resizes the cropped image to `1024x1024` before model preprocessing
- Added debug preprocessing metadata output when `DEBUG=True`
  - Records source, `WEBCAM_IMAGE_SIZE`, scale, crop size, original image size, and inference image size

