### PR TITLE
Add macOS installer package workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+CYTOLONE-*-mac-arm64/
 develop-eggs/
 dist/
 downloads/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 <picture>
   <img alt="cytolone logo" src="/assets/cytolone_logo.jpg" width="80%" height="80%">
-</picture> 
+</picture>
 
 _**"Always by you side."**_
-  
+
 </div>
 
 <br>
@@ -12,7 +12,7 @@ _**"Always by you side."**_
 |[日本語](./README_JA.md)|
 
 ## ✨ Overview
-**CYTOLONE** (Cytology All-in-One) is a real-time AI-powered support tool for **cytotechnologists in cervical cytology**.  
+**CYTOLONE** (Cytology All-in-One) is a real-time AI-powered support tool for **cytotechnologists in cervical cytology**.
 Unlike conventional AI systems that require **whole slide imaging (WSI)**, CYTOLONE operates **without WSI**, enabling **low-cost and high-speed AI support** using just an iPhone and an Apple Silicon Mac.
 
 Key Features:
@@ -21,7 +21,7 @@ Key Features:
 - **High-accuracy classification using hierarchical labeling**: Covers Anomaly, Malignancy, Bethesda, and Diagnosis categories
 - **Optional LLM-based findings generation**
 
-For more details, see the published paper:  
+For more details, see the published paper:
 [🔗 Whole Slide Imaging-Free Supporting Tool for Cytotechnologists in Cervical Cytology (Modern Pathology 2025)](https://doi.org/10.1016/j.modpat.2025.100817)
 
 Below is an example image used in the study:
@@ -35,225 +35,231 @@ Below is an example image used in the study:
   <img src="/assets/cytolone_app.png" alt="CYTOLONE App Image" width="100%">
 </div>
 
-## 🤩 Update History
-- **2026/05/05**
-  - Added the CYTOLONE launcher.
-  - You can now open CYTOLONE Main, scale-check, Settings, and Model Download from `cytolone`.
-  - Added continuous camera input for smoother microscope workflows.
-  - You no longer need to press the default camera capture button each time. Keep the camera connected and press the **Analyze** button to evaluate the current view.
-
-- **2026/02/16**
-  - Released CYTOLONE v1.1.3!
-  - Made `scale-check` semi-automated!
-
-- **2025/09/10**
-  - Released CYTOLONE-v1.1.1!
-  - LLM selection is now supported!  
-    Available LLMs: MLX versions of `DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit`, `gpt-oss-120b-MXFP4-Q4`, and `gpt-oss-20b-MXFP4-Q8`.
-  - UI updated.
-
-- **2025/07/03**
-  - Released CYTOLONE-v1.1!
-  - Improved performance over v1.0, especially on Bethesda and Diagnosis tasks
-  - See the Model Card for details: https://huggingface.co/kuri54/mlx-CYTOLONE-v1.1
-
-- **2025/07/03**
-  - Migrated setup from `setup.py` to `pyproject.toml`
-  - Added support for `uv` script execution
-
-- **2025/06/13**
-  - Public release of this page
-  - Publication of the research paper in *Modern Pathology*
-
-
 ## 💡 Usage
 - This library is optimized **only** for Apple Silicon Macs and iPhones.
 - It does **not support Windows or other operating systems**, and other camera devices are untested.
 
-### 💻 Setup
-0. **Preparation**
-    - Prepare an Apple Silicon Mac and iPhone, and log in with the **same Apple ID**.  
-    - Connect your Mac and iPhone using a **USB-C cable** (**or Thunderbolt cable**) .  
-    📝 Note:  
-      > Bluetooth is supported, but **a wired connection is recommended for  better stability**.  
-    - Connect your iPhone to the microscope using an adapter.
- 
+### 💻 Physical Setup
+1. Prepare an Apple Silicon Mac and iPhone, and log in with the **same Apple ID**.
+2. Connect your Mac and iPhone using a **USB-C cable** or **Thunderbolt cable**.
+3. Connect your iPhone to the microscope using an adapter.
+
+📝 Note:
+> Bluetooth is supported, but **a wired connection is recommended for better stability**.
+
 <div align="center">
   <img src="/assets/setup.png" alt="Setup" width="80%">
 </div>
 
-1. **Install Python**
+### 📦 Recommended Install: GitHub Releases Package
+This is the recommended setup for regular users. You do **not** need to clone this repository, install Homebrew, or create a shell alias.
 
-    📢 Important:  
-    > macOS comes with Python pre-installed, but the version is outdated and cannot install the latest libraries required by this app.  
-    > Please install **Python 3.12**.
+1. Open the [GitHub Releases page](https://github.com/kuri54/CYTOLONE/releases).
+2. Download the macOS Apple Silicon package:
+   ```text
+   CYTOLONE-<version>-mac-arm64.tar.gz
+   ```
+3. Double-click the downloaded `.tar.gz` file to extract it.
+4. Open the extracted folder and double-click:
+   ```text
+   install.command
+   ```
+5. When the installer finishes, restart Terminal if needed.
+6. Launch CYTOLONE from Terminal:
+   ```bash
+   cytolone
+   ```
 
-    <br>
+The installer places CYTOLONE in:
+```text
+~/.local/share/cytolone/current
+```
 
-    ```bash
-    brew install python@3.12
-    ```
+It also creates this launcher:
+```text
+~/.local/bin/cytolone
+```
 
-    **For [uv](https://github.com/astral-sh/uv) users:**
-    ```bash
-    uv python install 3.12
-    ```
+If `uv` is already installed, the installer uses it as-is. If `uv` is not installed, the installer installs `uv` using the official `uv` installer. It does not use Homebrew.
 
-2. **Installation**:
-    - Clone this repository.
-     
-    - Move into the cloned directory:
-      ```bash
-      cd CYTOLONE
-      ```
+The project virtual environment is normally created at:
+```text
+~/.local/share/cytolone/current/.venv
+```
 
-    📝 Note:
-    > **For uv users:**
-    This section is unnecessary. Install dependencies with `uv sync`, then proceed to step 3.
+To uninstall CYTOLONE, double-click:
+```text
+uninstall.command
+```
 
-    <br>
+`uninstall.command` removes only the CYTOLONE install directory and the `~/.local/bin/cytolone` launcher. It does **not** remove `uv`, Python installed by `uv`, or the `uv` cache.
 
-    - Create and activate a virtual environment:
-      ```bash
-      python3.12 -m venv venv
-      source venv/bin/activate
-      ```
+### 🛠 Developer / Source Install
+Use this method if you want to run CYTOLONE from a cloned source checkout.
 
-      📝 Note:  
-      > Perform all subsequent steps **within this virtual environment**  
+1. Install Python 3.12.
 
-    <br>
+   macOS includes Python, but the preinstalled version is too old for this app.
 
-    - Install required libraries: 
-      ```bash
-      pip install -e .
-      ```
+   ```bash
+   brew install python@3.12
+   ```
 
+   For [uv](https://github.com/astral-sh/uv) users:
+   ```bash
+   uv python install 3.12
+   ```
 
+2. Clone this repository and move into it:
+   ```bash
+   git clone https://github.com/kuri54/CYTOLONE.git
+   cd CYTOLONE
+   ```
 
-3. **App Settings**
-    - Default settings:
-      ```
-      LANGUAGE = en --------------- App language setting (en or ja)
-      MODEL = v1.1 ---------------- Model version to use (choose v1.0 or v1.1)
-      LLM_MODEL = gpt-oss-20b ----- LLM to use (choose deepseek-r1 or gpt-oss-120b or gpt-oss-20b)
-      LLM_GEN = False ------------- Enable or disable LLM-based findings generation
-      LLM_GEN_THRESHOLD = 0.8 ----- Threshold for enabling LLM output
-      WEBCAM_IMAGE_SIZE = 1024 ---- Webcam input image size
-      ```
+3. Install dependencies.
 
-    - How to change settings
-      - You can edit settings from the launcher: run `cytolone` or `uv run cytolone`, then open **Settings**.
-      - The CLI commands remain available.
-      - Display all settings: 
-        ```bash
-        cytolone-config --list
-        ```
+   With `uv`:
+   ```bash
+   uv sync
+   ```
 
-      - Set the app language to Japanese: 
-        ```bash
-        cytolone-config --LANGUAGE ja
-        ```
+   With `venv` and `pip`:
+   ```bash
+   python3.12 -m venv venv
+   source venv/bin/activate
+   pip install -e .
+   ```
 
-      - Reset to default settings:
-        ```bash
-        cytolone-config --reset
-        ```
+4. Launch from the source checkout:
+   ```bash
+   uv run cytolone
+   ```
 
-        ⚠️ Warning:  
-        Enable `LLM_GEN` **only if your Mac has at least 64GB of unified memory**.  
-        Insufficient memory **may cause system crashes**.
+### ⚙️ App Settings
+Default settings:
+```text
+LANGUAGE = en --------------- App language setting (en or ja)
+MODEL = v1.1 ---------------- Model version to use (choose v1.0 or v1.1)
+LLM_MODEL = gpt-oss-20b ----- LLM to use (choose deepseek-r1 or gpt-oss-120b or gpt-oss-20b)
+LLM_GEN = False ------------- Enable or disable LLM-based findings generation
+LLM_GEN_THRESHOLD = 0.8 ----- Threshold for enabling LLM output
+WEBCAM_IMAGE_SIZE = 1024 ---- Webcam input image size
+```
 
-    - `WEBCAM_IMAGE_SIZE`  
-       📢 Important:  
-       > `WEBCAM_IMAGE_SIZE` is the **most critical setting** in this app.  
-       > Please check [this guide](/CYTOLONE/scale_check/README.md) for details.  
+You can edit settings from the launcher. Run `cytolone` or `uv run cytolone`, then open **Settings**.
 
-    <br>
+The CLI commands remain available:
+```bash
+cytolone-config --list
+cytolone-config --LANGUAGE ja
+cytolone-config --reset
+```
 
-    - Download the models
-      - You can download models from the launcher: run `cytolone` or `uv run cytolone`, then open **Model Download**.
-      - Already installed models are skipped automatically. Use **Force re-download** only when you want to download again.
-      - The CLI command remains available.
-      ```bash
-      download-model
-      ```
-      - Required models will be downloaded automatically.  
-      - If `LLM_GEN` is set to `False`, **language models will not be downloaded**.  
-        To use LLM features, change the setting to `True` and run the command again.  
+⚠️ Warning:
+> Enable `LLM_GEN` **only if your Mac has at least 64GB of unified memory**.
+> Insufficient memory **may cause system crashes**.
 
-      ⚠️ Warning:  
-      > `download-model` **requires an internet connection**.  
-      > For offline environments, temporarily connect to the internet or manually download the models on another PC and place them in the specified directories.
+`WEBCAM_IMAGE_SIZE` is the **most critical setting** in this app. Please check [this guide](/CYTOLONE/scale_check/README.md) for details.
 
-      Download links:  
-      [kuri54/mlx-CYTOLONE-v1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1)  
-      [kuri54/mlx-CYTOLONE-v1.1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1.1)  
-      [mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit](https://huggingface.co/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit)  
-      [mlx-community/gpt-oss-120b-MXFP4-Q4](https://huggingface.co/mlx-community/gpt-oss-120b-MXFP4-Q4)  
-      [mlx-community/gpt-oss-20b-MXFP4-Q8](https://huggingface.co/mlx-community/gpt-oss-20b-MXFP4-Q8)  
+### ⬇️ Model Download
+You can download models from the launcher. Run `cytolone` or `uv run cytolone`, then open **Model Download**.
 
-      Place the models in the following directories:  
-      ```
-      CYTOLONE/mlx-models/kuri54/mlx-CYTOLONE-v1/  
-      CYTOLONE/mlx-models/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit/
-      ```
+Already installed models are skipped automatically. Use **Force re-download** only when you want to download again.
+
+The CLI command remains available:
+```bash
+download-model
+```
+
+Required models will be downloaded automatically. If `LLM_GEN` is set to `False`, **language models will not be downloaded**. To use LLM features, change the setting to `True` and download models again.
+
+⚠️ Warning:
+> Model download **requires an internet connection**.
+> For offline environments, temporarily connect to the internet or manually download the models on another PC and place them in the specified directories.
+
+Download links:
+[kuri54/mlx-CYTOLONE-v1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1)
+[kuri54/mlx-CYTOLONE-v1.1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1.1)
+[mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit](https://huggingface.co/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit)
+[mlx-community/gpt-oss-120b-MXFP4-Q4](https://huggingface.co/mlx-community/gpt-oss-120b-MXFP4-Q4)
+[mlx-community/gpt-oss-20b-MXFP4-Q8](https://huggingface.co/mlx-community/gpt-oss-20b-MXFP4-Q8)
+
+Place the models in the following directories:
+```text
+CYTOLONE/mlx-models/kuri54/mlx-CYTOLONE-v1/
+CYTOLONE/mlx-models/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit/
+```
 
 ### 🚀 Launch the App
-- Launch:
-    ```bash
-    cytolone
-    ```
-    or:
-    ```bash
-    uv run cytolone
-    ```
-    - The CYTOLONE launcher opens first.
-    - From the launcher, you can open CYTOLONE Main, scale-check, Settings, and Model Download.
-    - Only the Launcher tab is shown in the navigation bar; use the launcher buttons to open each page.
-    - Open the URL displayed in the terminal in your web browser.
-    - Click **CYTOLONE Main** to open the existing analysis screen.
-    - Simply select your camera, capture an image, and click the Analyze button to view the results.
+For package users:
+```bash
+cytolone
+```
 
-    <br>
+To run directly from the installed package directory:
+```bash
+cd ~/.local/share/cytolone/current
+uv run cytolone
+```
 
-    📝 Note:  
-    > Works offline as well!  
+For source checkout users:
+```bash
+uv run cytolone
+```
+
+- The CYTOLONE launcher opens first.
+- From the launcher, you can open CYTOLONE Main, scale-check, Settings, and Model Download.
+- Only the Launcher tab is shown in the navigation bar; use the launcher buttons to open each page.
+- Open the URL displayed in the terminal in your web browser.
+- Click **CYTOLONE Main** to open the existing analysis screen.
+- Select your camera and click **Analyze** to evaluate the current view.
+
+📝 Note:
+> After dependencies and models are installed, CYTOLONE can run offline.
+
+### 🌐 Network and Storage Notes
+- Downloading the `.tar.gz` package from GitHub Releases requires network access.
+- `install.command` uses the network only when `uv` is not already installed.
+- The first `cytolone` launch may use the network while `uv` installs Python packages.
+- Model download uses the network and can require substantial disk space.
+- CYTOLONE does not modify Tailscale, Taildrive, Owlfile, or network sharing settings.
+- If your home directory is synced or shared by another tool, note that `~/.local/share/cytolone/current/.venv` and downloaded models can be large.
+- The top-level `assets/` directory is used for GitHub README images and is not required in the release package.
 
 <br>
 
-- Camera Connection  
-Click the red button to connect to your iPhone.  
+### 📷 Camera Connection
+Click the red button to connect to your iPhone.
 <div align="center">
   <img src="/assets/webcam.png" alt="Webcam" width="60%">
 </div>
 
 <br>
 
-💡 Tip:  
+💡 Tip:
 > If your face appears using the built-in Mac camera, select your iPhone once. CYTOLONE remembers that iPhone in the browser and tries to reconnect it automatically the next time.
 > If Center Stage is enabled when using the iPhone camera, turn it off from the Mac menu bar video menu, or from Control Center > Video Effects. This is a macOS Continuity Camera setting, not a CYTOLONE setting.
 
 <br>
 
-⚠️ Warning:  
-> Make sure to use the x10 objective lens when taking photos.  
-> Other magnifications are not supported.  
+⚠️ Warning:
+> Make sure to use the x10 objective lens when taking photos.
+> Other magnifications are not supported.
 
 ## 🔭 Planned Features
 The following features are planned for future updates:
 
-- **Region-of-Interest Highlighting with Red Circles**  
-  Users will be able to place a red circle on any part of the image to prompt the model to focus on that specific area during evaluation.  
+- **Region-of-Interest Highlighting with Red Circles**
+  Users will be able to place a red circle on any part of the image to prompt the model to focus on that specific area during evaluation.
   _Reference_: [What does CLIP know about a red circle? Visual prompt engineering for VLMs](https://arxiv.org/pdf/2304.06712)
 
-- **Screening Mode**  
-  When enabled, this mode will continuously evaluate the "Anomaly" category in real time during microscopic observation.  
+- **Screening Mode**
+  When enabled, this mode will continuously evaluate the "Anomaly" category in real time during microscopic observation.
 
 ## 🎉 Citation
 ```
 @article{kurita2025cytolone,
-         title={Whole Slide Imaging-Free Supporting Tool for Cytotechnologists in Cervical Cytology}, 
+         title={Whole Slide Imaging-Free Supporting Tool for Cytotechnologists in Cervical Cytology},
          author={Yuki Kurita et al.},
          year={2025},
          journal={Modern Pathology},

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,16 +1,16 @@
 <div align="center">
 <picture>
   <img alt="cytolone logo" src="/assets/cytolone_logo.jpg" width="80%" height="80%">
-</picture> 
+</picture>
 
 _**"Always by you side."**_
-  
+
 </div>
 
 <br>
 
 ## ✨ 概要
-**CYTOLONE** (Cytology All-in-One) は、顕微鏡とAIをリアルタイムで連携させることで、**細胞検査士による子宮頸部細胞診のスクリーニングを支援するツール**です。  
+**CYTOLONE** (Cytology All-in-One) は、顕微鏡とAIをリアルタイムで連携させることで、**細胞検査士による子宮頸部細胞診のスクリーニングを支援するツール**です。
 従来のAI支援システムで必要とされていた**WSI（全スライド画像）作成を不要**とし、iPhoneとApple Silicon Macだけで運用可能な低コスト・高速AI支援を実現しました。
 
 主な特徴:
@@ -19,7 +19,7 @@ _**"Always by you side."**_
 - **階層ラベル学習による高精度判定**：異常、悪性、ベセスダ分類、診断まで対応
 - **LLM（大規模言語モデル）による所見生成（オプション）**
 
-詳細は論文をご参照ください：  
+詳細は論文をご参照ください：
 [🔗 Whole Slide Imaging-Free Supporting Tool for Cytotechnologists in Cervical Cytology (Modern Pathology 2025)](https://doi.org/10.1016/j.modpat.2025.100817)
 
 下図は実際の研究で使用した画像例です：
@@ -33,222 +33,227 @@ _**"Always by you side."**_
   <img src="/assets/cytolone_app.png" alt="CYTOLONE App Image" width="100%">
 </div>
 
-## 🤩 アップデート履歴
-- **2026年5月5日**
-  - CYTOLONE ランチャーを実装しました。
-  - `cytolone` から CYTOLONE Main、scale-check、Settings、Model Download を開けるようになりました。
-  - 顕微鏡ワークフロー向けに、継続したカメラ入力に対応しました。
-  - これまでのように毎回カメラの撮影ボタンを押す必要はありません。カメラ接続を維持したまま、**Analyze** ボタンで現在の視野を判定できます。
-
-- **2026年2月16日**
-  - CYTOLONE-v1.1.3 をリリース！
-  - scale-checkを半自動化しました！
-
-- **2025年9月3日**
-  - CYTOLONE-v1.1.1 をリリース！
-  - LLMの選択に対応しました！  
-    利用可能なLLMは`DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit`、`gpt-oss-120b-MXFP4-Q4`、`gpt-oss-20b-MXFP4-Q8`のMLXバージョンです。
-  - UIを更新しました。
-
-- **2025年7月10日**
-  - CYTOLONE-v1.1 をリリース！
-  - v1.0 と比較して、特に Bethesda／Diagnosis タスクの性能を向上
-  - 詳細は Model Card をご覧ください：https://huggingface.co/kuri54/mlx-CYTOLONE-v1.1
-
-- **2025年7月3日**
-  - セットアップ関係をアップデート
-  - uvのスクリプト実行に対応
-
-- **2025年6月13日**
-  - ページを公開しました
-  - 論文が *Modern Pathology* に掲載されました
-
-
-## 💡使用方法
+## 💡 使用方法
 - このライブラリは**Apple Silicon MacとiPhoneのみ**に最適化されています。
 - Windowsやその他のOSは対応していません。その他のカメラデバイスは未検証です。
 
-### 💻 セットアップ
-0. **事前準備**
-    - Apple Silicon MacとiPhoneを用意し、同一のApple IDでログインする。  
-    - MacとiPhoneをUSB-Cケーブル（もしくはThunderboltケーブル）で接続する。  
-      📝 Note:  
-      > Bluetoothでも接続が可能ですが、有線接続の方が安定するためおすすめです  
-    - iPhoneと顕微鏡をアダプターで接続する。
+### 💻 事前準備
+1. Apple Silicon Mac と iPhone を用意し、同一の Apple ID でログインします。
+2. Mac と iPhone を USB-C ケーブル、または Thunderbolt ケーブルで接続します。
+3. iPhone と顕微鏡をアダプターで接続します。
+
+📝 Note:
+> Bluetooth でも接続できますが、安定性のため有線接続を推奨します。
 
 <div align="center">
   <img src="/assets/setup.png" alt="Setup" width="80%">
 </div>
 
-1. **Pythonのインストール**
+### 📦 推奨インストール: GitHub Releases パッケージ
+通常利用ではこの方法を推奨します。Git clone、Homebrew、alias の設定は不要です。
 
-    📢 Important:  
-    > MacにはPythonが標準でインストールされていますが、バージョンが古いため本アプリで使用する主要なライブラリの最新バージョンがインストールできません。  
-    > **Python3.12**をインストールしてください。
+1. [GitHub Releases ページ](https://github.com/kuri54/CYTOLONE/releases)を開きます。
+2. macOS Apple Silicon 用パッケージをダウンロードします。
+   ```text
+   CYTOLONE-<version>-mac-arm64.tar.gz
+   ```
+3. ダウンロードした `.tar.gz` をダブルクリックして展開します。
+4. 展開されたフォルダを開き、次のファイルをダブルクリックします。
+   ```text
+   install.command
+   ```
+5. インストール完了後、必要に応じて Terminal を再起動します。
+6. Terminal で次のコマンドを実行して起動します。
+   ```bash
+   cytolone
+   ```
 
-    <br>
+インストーラは CYTOLONE を次の場所に配置します。
+```text
+~/.local/share/cytolone/current
+```
 
-    ```bash
-    brew install python@3.12
-    ```
+また、次の起動用ラッパーを作成します。
+```text
+~/.local/bin/cytolone
+```
 
-    **For [uv](https://github.com/astral-sh/uv) users:**
-    ```bash
-    uv python install 3.12
-    ```
+`uv` がすでにインストールされている場合、インストーラは既存の `uv` をそのまま使用します。`uv` がない場合のみ、公式の `uv` インストーラで導入します。Homebrew は使用しません。
 
-2. **Installation**:
-    - リポジトリをcloneする
-     
-    - cloneしたディレクトリに移動
-      ```bash
-      cd CYTOLONE
-      ```
+uv の仮想環境は通常、次の場所に作成されます。
+```text
+~/.local/share/cytolone/current/.venv
+```
 
-    📝 Note:
-    > **For uv users:**
-    このセクションは不要です。`uv sync`で依存関係をインストール後、次のステップ3へ進んでください。
+アンインストールする場合は、次のファイルをダブルクリックします。
+```text
+uninstall.command
+```
 
-    <br>
+`uninstall.command` は CYTOLONE の配置先と `~/.local/bin/cytolone` だけを削除します。`uv` 本体、`uv` がインストールした Python、`uv` cache は削除しません。
 
-    - 仮想環境の構築
-        ```bash
-        python3.12 -m venv venv
-        source venv/bin/activate
-        ```
+### 🛠 開発者向け / ソースからのインストール
+clone したソースツリーから CYTOLONE を実行したい場合はこちらを使用してください。
 
-        📝 Note:  
-        > 以降の作業は全てこの仮想環境内で実行する  
+1. Python 3.12 をインストールします。
 
-    <br>
+   Mac には Python が標準でインストールされていますが、バージョンが古いため本アプリで使用する主要なライブラリを利用できません。
 
-    - 必要なライブラリをインストールする
-      ```bash
-      pip install -e .
-      ```
+   ```bash
+   brew install python@3.12
+   ```
 
+   [uv](https://github.com/astral-sh/uv) を使う場合:
+   ```bash
+   uv python install 3.12
+   ```
 
+2. リポジトリを clone し、ディレクトリに移動します。
+   ```bash
+   git clone https://github.com/kuri54/CYTOLONE.git
+   cd CYTOLONE
+   ```
 
-3. **アプリの設定**
-    - デフォルト設定
-        ```
-        LANGUAGE = en --------------- アプリの言語設定 (en or ja)
-        MODEL = v1.1 ---------------- 使用するモデルのバージョン（v1.0 または v1.1）
-        LLM_MODEL = gpt-oss-20b ----- 使用するLLM (deepseek-r1 or gpt-oss-120b or gpt-oss-20b)
-        LLM_GEN = False ------------- LLMによる鑑別所見出力の有無
-        LLM_GEN_THRESHOLD = 0.8 ----- LLM出力を有効にする閾値
-        WEBCAM_IMAGE_SIZE = 1024 ---- webcam入力画像サイズ
-        ```
+3. 依存関係をインストールします。
 
-    - 設定変更方法
-        - ランチャーから設定を変更できます。`cytolone` または `uv run cytolone` を実行し、**Settings** を開いてください。
-        - CLI コマンドも引き続き利用できます。
-        - 設定一覧を表示: 
-          ```bash
-          cytolone-config --list
-          ```
+   `uv` を使う場合:
+   ```bash
+   uv sync
+   ```
 
-        - アプリの言語を日本語にする: 
-          ```bash
-          cytolone-config --LANGUAGE ja
-          ```
+   `venv` と `pip` を使う場合:
+   ```bash
+   python3.12 -m venv venv
+   source venv/bin/activate
+   pip install -e .
+   ```
 
-        - 設定をデフォルトに戻す: 
-          ```bash
-          cytolone-config --reset
-          ```
+4. ソースツリーから起動します。
+   ```bash
+   uv run cytolone
+   ```
 
-          ⚠️ Warning:  
-          `LLM_GEN`を`True`にする場合は、Macが少なくとも**64GB以上のユニファイドメモリ**を搭載している場合のみにしてください。メモリが少ない場合はMacがクラッシュします。
+### ⚙️ アプリの設定
+デフォルト設定:
+```text
+LANGUAGE = en --------------- アプリの言語設定 (en or ja)
+MODEL = v1.1 ---------------- 使用するモデルのバージョン（v1.0 または v1.1）
+LLM_MODEL = gpt-oss-20b ----- 使用するLLM (deepseek-r1 or gpt-oss-120b or gpt-oss-20b)
+LLM_GEN = False ------------- LLMによる鑑別所見出力の有無
+LLM_GEN_THRESHOLD = 0.8 ----- LLM出力を有効にする閾値
+WEBCAM_IMAGE_SIZE = 1024 ---- webcam入力画像サイズ
+```
 
-      - `WEBCAM_IMAGE_SIZE`  
-         📢 Important:  
-         > `WEBCAM_IMAGE_SIZE`はこのアプリで最も重要な設定です。  
-         > 設定方法は[こちらの手順](/CYTOLONE/scale_check/README_JA.md)を確認してください。  
+ランチャーから設定を変更できます。`cytolone` または `uv run cytolone` を実行し、**Settings** を開いてください。
 
-    <br>
+CLI コマンドも引き続き利用できます。
+```bash
+cytolone-config --list
+cytolone-config --LANGUAGE ja
+cytolone-config --reset
+```
 
-    - モデルのダウンロード
-      - ランチャーからモデルをダウンロードできます。`cytolone` または `uv run cytolone` を実行し、**Model Download** を開いてください。
-      - すでにインストール済みのモデルは自動的にスキップされます。再ダウンロードしたい場合のみ **Force re-download** を使用してください。
-      - CLI コマンドも引き続き利用できます。
-      ```bash
-      download-model
-      ```
-      - 自動的に必要なモデルがダウンロードされます。  
-      - `LLM_GEN`が`False`の場合、言語モデルはダウンロードされません。LLM機能を利用したい場合は、設定変更後に再実行してください。  
+⚠️ Warning:
+> `LLM_GEN` を `True` にする場合は、Mac が少なくとも **64GB 以上のユニファイドメモリ**を搭載している場合のみにしてください。メモリが少ない場合は Mac がクラッシュする可能性があります。
 
-      ⚠️ Warning:  
-      > `download-model`実行時は**ネット接続が必要**です。  
-      > オフライン環境の場合は、一時的にネットワークに繋げるか、別のネットワークに繋がったPCで以下のリンクからモデルをダウンロードし、指定のディレクトリに配置してください。
+`WEBCAM_IMAGE_SIZE` はこのアプリで最も重要な設定です。設定方法は[こちらの手順](/CYTOLONE/scale_check/README_JA.md)を確認してください。
 
-        リンク:   
-        [kuri54/mlx-CYTOLONE-v1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1)  
-        [kuri54/mlx-CYTOLONE-v1.1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1.1)  
-        [mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit](https://huggingface.co/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit)  
-        [mlx-community/gpt-oss-120b-MXFP4-Q4](https://huggingface.co/mlx-community/gpt-oss-120b-MXFP4-Q4)  
-        [mlx-community/gpt-oss-20b-MXFP4-Q8](https://huggingface.co/mlx-community/gpt-oss-20b-MXFP4-Q8)  
+### ⬇️ モデルのダウンロード
+ランチャーからモデルをダウンロードできます。`cytolone` または `uv run cytolone` を実行し、**Model Download** を開いてください。
 
-        配置:  
-        ```
-        CYTOLONE/mlx-models/kuri54/mlx-CYTOLONE-v1/  
-        CYTOLONE/mlx-models/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit/
-        ```
+すでにインストール済みのモデルは自動的にスキップされます。再ダウンロードしたい場合のみ **Force re-download** を使用してください。
+
+CLI コマンドも引き続き利用できます。
+```bash
+download-model
+```
+
+自動的に必要なモデルがダウンロードされます。`LLM_GEN` が `False` の場合、言語モデルはダウンロードされません。LLM 機能を利用したい場合は、設定変更後に再度ダウンロードしてください。
+
+⚠️ Warning:
+> モデルのダウンロードには**ネット接続が必要**です。
+> オフライン環境の場合は、一時的にネットワークに繋げるか、別のネットワークに繋がった PC で以下のリンクからモデルをダウンロードし、指定のディレクトリに配置してください。
+
+リンク:
+[kuri54/mlx-CYTOLONE-v1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1)
+[kuri54/mlx-CYTOLONE-v1.1](https://huggingface.co/kuri54/mlx-CYTOLONE-v1.1)
+[mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit](https://huggingface.co/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit)
+[mlx-community/gpt-oss-120b-MXFP4-Q4](https://huggingface.co/mlx-community/gpt-oss-120b-MXFP4-Q4)
+[mlx-community/gpt-oss-20b-MXFP4-Q8](https://huggingface.co/mlx-community/gpt-oss-20b-MXFP4-Q8)
+
+配置:
+```text
+CYTOLONE/mlx-models/kuri54/mlx-CYTOLONE-v1/
+CYTOLONE/mlx-models/mlx-community/DeepSeek-R1-Distill-Qwen-32B-Japanese-8bit/
+```
 
 ### 🚀 アプリの起動
-- 起動
-    ```bash
-    cytolone
-    ```
-    または:
-    ```bash
-    uv run cytolone
-    ```
-    - 最初に CYTOLONE ランチャー画面が開きます。
-    - ランチャーから CYTOLONE メイン、scale-check、設定変更、モデルDL を開けます。
-    - ナビゲーションバーには Launcher タブだけが表示されます。各ページへはランチャー内のボタンから移動してください。
-    - ターミナルに表示されたアドレスにWebブラウザでアクセスする。  
-    - **CYTOLONE Main** を押すと、従来の解析画面が開きます。
-    - カメラ選択 → 写真撮影 → **Analyze ボタンをクリック** するだけで判定結果が表示されます。
+パッケージ利用者:
+```bash
+cytolone
+```
 
-    <br>
+インストール先で直接起動する場合:
+```bash
+cd ~/.local/share/cytolone/current
+uv run cytolone
+```
 
-    📝 Note:  
-    > オフラインでも利用可能です！  
+ソースツリーから起動する場合:
+```bash
+uv run cytolone
+```
 
-<br>
+- 最初に CYTOLONE ランチャー画面が開きます。
+- ランチャーから CYTOLONE Main、scale-check、Settings、Model Download を開けます。
+- ナビゲーションバーには Launcher タブだけが表示されます。各ページへはランチャー内のボタンから移動してください。
+- ターミナルに表示されたアドレスに Web ブラウザでアクセスしてください。
+- **CYTOLONE Main** を押すと、従来の解析画面が開きます。
+- カメラを選択し、**Analyze** ボタンをクリックすると現在の視野を判定できます。
 
-- カメラの連携  
-赤丸部分をクリックしてiPhoneと連携してください。  
+📝 Note:
+> 依存関係とモデルの準備が完了した後は、オフラインでも利用可能です。
+
+### 🌐 ネットワークとストレージに関する注意
+- GitHub Releases から `.tar.gz` を取得する時にネットワークを使用します。
+- `install.command` は `uv` が未インストールの場合のみネットワークを使用します。
+- 初回 `cytolone` 起動時に、`uv` が Python パッケージを取得するためネットワークを使用する場合があります。
+- モデルのダウンロードにはネットワークを使用し、ディスク容量も大きくなる場合があります。
+- CYTOLONE は Tailscale、Taildrive、Owlfile、ネットワーク共有設定を変更しません。
+- ホームディレクトリを別ツールで同期・共有している場合、`~/.local/share/cytolone/current/.venv` やダウンロード済みモデルの容量に注意してください。
+- トップレベルの `assets/` は GitHub README 表示用であり、release パッケージの実行には不要です。
+
+### 📷 カメラの連携
+赤丸部分をクリックしてiPhoneと連携してください。
 <div align="center">
   <img src="/assets/webcam.png" alt="Webcam" width="60%">
 </div>
 
 <br>
 
-💡 Tip:  
+💡 Tip:
 > 内蔵カメラに自分の顔が映る場合は、一度 iPhone を選択してください。CYTOLONE はブラウザにその iPhone を記憶し、次回以降は自動再接続を試みます。
 > iPhone カメラ接続時にセンターフレームが有効になる場合は、Mac のメニューバーのビデオメニュー、またはコントロールセンター > ビデオエフェクトからセンターフレームをOFFにしてください。これは CYTOLONE ではなく macOS の連係カメラ設定です。
 
 <br>
 
-⚠️ Warning:  
-> 写真を撮る際の対物レンズは必ず×10にしてください。それ以外の倍率には対応していません。  
+⚠️ Warning:
+> 写真を撮る際の対物レンズは必ず×10にしてください。それ以外の倍率には対応していません。
 
 ## 🔭 今後の開発計画
 以下の機能を今後のアップデートで追加予定です：
 
-- **赤丸による注視領域の指定機能**  
-  画像上の任意の部位に赤丸をつけることで、モデルがその領域に注目して判定を行います。  
+- **赤丸による注視領域の指定機能**
+  画像上の任意の部位に赤丸をつけることで、モデルがその領域に注目して判定を行います。
   _参考論文_: [What does CLIP know about a red circle? Visual prompt engineering for VLMs](https://arxiv.org/pdf/2304.06712)
 
-- **スクリーニングモード**  
-  このモードをONにすると、顕微鏡観察中に常時「Anomaly」カテゴリの判定を自動実行します。  
+- **スクリーニングモード**
+  このモードをONにすると、顕微鏡観察中に常時「Anomaly」カテゴリの判定を自動実行します。
 
 ## 🎉 Citation
 ```
 @article{kurita2025cytolone,
-         title={Whole Slide Imaging-Free Supporting Tool for Cytotechnologists in Cervical Cytology}, 
+         title={Whole Slide Imaging-Free Supporting Tool for Cytotechnologists in Cervical Cytology},
          author={Yuki Kurita et al.},
          year={2025},
          journal={Modern Pathology},

--- a/install.command
+++ b/install.command
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="CYTOLONE"
+INSTALL_ROOT="${HOME}/.local/share/cytolone"
+INSTALL_DIR="${INSTALL_ROOT}/current"
+BIN_DIR="${HOME}/.local/bin"
+WRAPPER="${BIN_DIR}/cytolone"
+TMP_DIR=""
+
+cleanup() {
+    if [ -n "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+pause_before_exit() {
+    local status="$?"
+
+    cleanup
+
+    if [ -t 0 ]; then
+        echo ""
+        read -r -p "Press Enter to close this window..." _
+    fi
+
+    exit "$status"
+}
+trap pause_before_exit EXIT
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+append_path_if_needed() {
+    local rc_file="$1"
+    local path_line='export PATH="$HOME/.local/bin:$PATH"'
+
+    if [ ! -f "$rc_file" ]; then
+        touch "$rc_file"
+    fi
+
+    if ! grep -Fq "$path_line" "$rc_file"; then
+        {
+            echo ""
+            echo "# Added by CYTOLONE installer"
+            echo "$path_line"
+        } >> "$rc_file"
+    fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[ "$(uname -s)" = "Darwin" ] || fail "${APP_NAME} supports macOS only."
+[ "$(uname -m)" = "arm64" ] || fail "${APP_NAME} supports Apple Silicon Macs only."
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv not found. Installing uv with the official installer..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+command -v uv >/dev/null 2>&1 || fail "uv installation failed. Add ~/.local/bin to PATH and retry."
+
+mkdir -p "$INSTALL_ROOT" "$BIN_DIR"
+
+TMP_DIR="$(mktemp -d "${INSTALL_ROOT}/.install.XXXXXX")"
+
+rsync -a --delete \
+    --exclude ".git/" \
+    --exclude ".venv/" \
+    --exclude "venv/" \
+    --exclude "dist/" \
+    --exclude "debug_images/" \
+    --exclude "mlx_models/" \
+    --exclude "__pycache__/" \
+    --exclude "*.pyc" \
+    --exclude ".DS_Store" \
+    "${SCRIPT_DIR}/" "${TMP_DIR}/"
+
+rm -rf "$INSTALL_DIR"
+mv "$TMP_DIR" "$INSTALL_DIR"
+TMP_DIR=""
+
+cat > "$WRAPPER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$INSTALL_DIR"
+exec uv run cytolone "\$@"
+EOF
+chmod +x "$WRAPPER"
+
+append_path_if_needed "${HOME}/.zshrc"
+append_path_if_needed "${HOME}/.bashrc"
+
+echo "${APP_NAME} installed."
+echo "Run: cytolone"
+echo "If your current shell cannot find cytolone, restart Terminal or run:"
+echo '  export PATH="$HOME/.local/bin:$PATH"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "CYTOLONE"
-version = "1.1.4"
+version = "1.1.5"
 requires-python = "==3.12.*"
 dependencies = [
     "accelerate>=1.6.0",

--- a/scripts/package_macos.sh
+++ b/scripts/package_macos.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || fail "Usage: bash scripts/package_macos.sh v0.1.0"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${ROOT_DIR}/dist"
+PACKAGE_NAME="CYTOLONE-${VERSION}-mac-arm64"
+STAGING_DIR="${DIST_DIR}/${PACKAGE_NAME}"
+ARCHIVE_PATH="${DIST_DIR}/${PACKAGE_NAME}.tar.gz"
+
+required_paths=(
+    "CYTOLONE"
+    "pyproject.toml"
+    "uv.lock"
+    "install.command"
+    "uninstall.command"
+)
+
+optional_paths=(
+    "README.md"
+    "README_JA.md"
+    "LICENSE"
+)
+
+for path in "${required_paths[@]}"; do
+    [ -e "${ROOT_DIR}/${path}" ] || fail "Required path not found: ${path}"
+done
+
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR"
+
+for path in "${required_paths[@]}"; do
+    rsync -a \
+        --exclude "__pycache__/" \
+        --exclude "*.pyc" \
+        --exclude ".DS_Store" \
+        "${ROOT_DIR}/${path}" "$STAGING_DIR/"
+done
+
+for path in "${optional_paths[@]}"; do
+    if [ -e "${ROOT_DIR}/${path}" ]; then
+        rsync -a \
+            --exclude "__pycache__/" \
+            --exclude "*.pyc" \
+            --exclude ".DS_Store" \
+            "${ROOT_DIR}/${path}" "$STAGING_DIR/"
+    fi
+done
+
+chmod +x "${STAGING_DIR}/install.command" "${STAGING_DIR}/uninstall.command"
+
+tar -C "$DIST_DIR" -czf "$ARCHIVE_PATH" "$PACKAGE_NAME"
+rm -rf "$STAGING_DIR"
+
+echo "Created ${ARCHIVE_PATH}"

--- a/uninstall.command
+++ b/uninstall.command
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${HOME}/.local/share/cytolone/current"
+BIN_WRAPPER="${HOME}/.local/bin/cytolone"
+
+rm -f "$BIN_WRAPPER"
+rm -rf "$INSTALL_DIR"
+
+echo "CYTOLONE uninstalled."
+echo "uv, uv-managed Python, uv cache, and shell startup files were not modified."

--- a/uv.lock
+++ b/uv.lock
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "cytolone"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary
- Add macOS Apple Silicon self-setup packaging with `install.command`, `uninstall.command`, and `scripts/package_macos.sh`.
- Update the English and Japanese READMEs for GitHub Releases distribution and remove the in-README update history.
- Bump CYTOLONE package metadata to `1.1.5`.

## Changes
- `install.command` installs CYTOLONE under `~/.local/share/cytolone/current` and creates `~/.local/bin/cytolone`.
- `uninstall.command` removes only the CYTOLONE install directory and launcher wrapper, leaving `uv`, uv-managed Python, and uv cache untouched.
- `scripts/package_macos.sh` builds `dist/CYTOLONE-<version>-mac-arm64.tar.gz` for release attachment.
- `.gitignore` excludes generated macOS package staging artifacts.
- README setup instructions now lead with the GitHub Releases package while preserving source install and `uv run cytolone` workflows.